### PR TITLE
Fix minor type in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Running treefmt-nix with flakes isn't hard. The library is exposed as the `lib` 
     in
     {
       # for `nix fmt`
-      formatter = eachSystem (pkgs: treefmtEval.${pkgs.sytem}.config.build.wrapper);
+      formatter = eachSystem (pkgs: treefmtEval.${pkgs.system}.config.build.wrapper);
       # for `nix flake check`
       checks = eachSystem (pkgs: {
         formatting = treefmtEval.${pkgs.sytem}.config.build.check self;


### PR DESCRIPTION
`${pkgs.sytem}` -> `${pkgs.system}`